### PR TITLE
should before asset-rev to enable fingerprinting for production envirome...

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "sprites"
   ],
   "ember-addon": {
-    "main": "ember-cli-spritesmith-main.js"
+    "main": "ember-cli-spritesmith-main.js",
+    "before": "broccoli-asset-rev"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
let `spritesmith-addon` excute before `asset-rev` to enable fingerprinting for production envirome.
